### PR TITLE
fix: autoscaling groups to NLBs attachment

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -6,16 +6,16 @@ This module creates https://docs.aws.amazon.com/eks/latest/userguide/managed-nod
 
 The `node_groups` variable is a map of objects. Each value of the map creates a node group referenced by its label. The value object can take any input accepted by the https://registry.terraform.io/modules/terraform-aws-modules/eks/aws/latest/submodules/eks-managed-node-group[eks-managed-node-group] or https://registry.terraform.io/modules/terraform-aws-modules/eks/aws/latest/submodules/self-managed-node-group[self-managed-node-group] submodule.
 
-Here is an example that creates one node group with 3 instances of type `r5a.large`, attaches them to the main Load Balancer, and customizes the base EBS volume size to 100 GB:
+Here is an example that creates one EKS managed node group with 3 instances of type `r5a.large`, attaches them to the cluster Load Balancer(s), and customizes the base EBS volume size to 100 GB:
 
 ----
   node_groups = {
     "my-node-group" = {
-      instance_type     = "r5a.xlarge"
-      min_size          = 3
-      max_size          = 3
-      desired_size      = 3
-      target_group_arns = module.my_cluster.nlb_target_groups
+      instance_types  = ["r5a.xlarge"]
+      min_size        = 3
+      max_size        = 3
+      desired_size    = 3
+      nlbs_attachment = true
 
       block_device_mappings = {
         "default" = {
@@ -29,6 +29,15 @@ Here is an example that creates one node group with 3 instances of type `r5a.lar
   }
 ----
 
+[NOTE]
+====
+When using self-managed node groups, the instance type is instead given as a single string value instead of an array:
+
+----
+      instance_type     = "r5a.xlarge"
+----
+====
+
 TIP: You can check out available instance types on the https://aws.amazon.com/ec2/instance-types[official AWS documentation pages].
 
 Depending on the `create_public_nlb` and `create_private_nlb` variables, it creates a public and/or public Network Load Balancer(s). The node groups that have the `target_group_arns = module.my_cluster.nlb_target_groups` value set will be added as backends of the LBs. By default, the LBs only forward traffic on the ports `80` and `443`, but you can customize this using the `extra_lb_target_groups` and `extra_lb_http_tcp_listeners` variables to add other ports. Look at the `lb.tf` file in this module for the syntax.
@@ -39,7 +48,15 @@ This module needs a Route 53 DNS zone in the same AWS account to create a wildca
 
 The versions 2.x and earlier of this module created https://docs.aws.amazon.com/eks/latest/userguide/worker.html[self-managed node groups] exclusively. Upgrading to versions 3.x or later requires setting the variable `use_self_managed_node_groups` to `true` to avoid breaking existing clusters.
 
-Switching an existing cluster to EKS managed node groups is possible, but requires manually draining the existing nodes after the new node group is created and before the old one is destroyed (by doing a `terraform apply -target <resource>` in multiple steps) as well as manually adding the new node group to the Load Balancer.
+[NOTE]
+====
+When going from self-managed node groups to EKS managed ones, note the following changes in node groups arguments:
+
+- The `instance_type` argument is replaced with `instance_types` and accepts a list of strings,
+- The `target_group_arns` arugment isn't supported anymore. Instead set `nlbs_attachment = true`.
+====
+
+Switching an existing cluster to EKS managed node groups is possible, but requires manually draining the existing nodes after the new node group is created and before the old one is destroyed (by doing a `terraform apply -target <resource>` in multiple steps).
 
 == Technical Reference
 

--- a/README.adoc
+++ b/README.adoc
@@ -360,9 +360,9 @@ Description: Kubernetes API endpoint and CA certificate as a structured value.
 [cols="a,a,a",options="header,autowidth"]
 |===
 |Name |Source |Version
+|[[module_cluster]] <<module_cluster,cluster>> |terraform-aws-modules/eks/aws |~> 19.0
 |[[module_nlb]] <<module_nlb,nlb>> |terraform-aws-modules/alb/aws |~> 8.0
 |[[module_nlb_private]] <<module_nlb_private,nlb_private>> |terraform-aws-modules/alb/aws |~> 8.0
-|[[module_cluster]] <<module_cluster,cluster>> |terraform-aws-modules/eks/aws |~> 19.0
 |===
 
 = Resources

--- a/README.adoc
+++ b/README.adoc
@@ -53,7 +53,7 @@ The versions 2.x and earlier of this module created https://docs.aws.amazon.com/
 When going from self-managed node groups to EKS managed ones, note the following changes in node groups arguments:
 
 - The `instance_type` argument is replaced with `instance_types` and accepts a list of strings,
-- The `target_group_arns` arugment isn't supported anymore. Instead set `nlbs_attachment = true`.
+- The `target_group_arns` argument isn't supported anymore. Instead set `nlbs_attachment = true`.
 ====
 
 Switching an existing cluster to EKS managed node groups is possible, but requires manually draining the existing nodes after the new node group is created and before the old one is destroyed (by doing a `terraform apply -target <resource>` in multiple steps).

--- a/README.adoc
+++ b/README.adoc
@@ -360,9 +360,9 @@ Description: Kubernetes API endpoint and CA certificate as a structured value.
 [cols="a,a,a",options="header,autowidth"]
 |===
 |Name |Source |Version
-|[[module_cluster]] <<module_cluster,cluster>> |terraform-aws-modules/eks/aws |~> 19.0
 |[[module_nlb]] <<module_nlb,nlb>> |terraform-aws-modules/alb/aws |~> 8.0
 |[[module_nlb_private]] <<module_nlb_private,nlb_private>> |terraform-aws-modules/alb/aws |~> 8.0
+|[[module_cluster]] <<module_cluster,cluster>> |terraform-aws-modules/eks/aws |~> 19.0
 |===
 
 = Resources

--- a/README.adoc
+++ b/README.adoc
@@ -81,12 +81,6 @@ The following providers are used by this module:
 
 The following Modules are called:
 
-==== [[module_cluster]] <<module_cluster,cluster>>
-
-Source: terraform-aws-modules/eks/aws
-
-Version: ~> 19.0
-
 ==== [[module_nlb]] <<module_nlb,nlb>>
 
 Source: terraform-aws-modules/alb/aws
@@ -99,10 +93,17 @@ Source: terraform-aws-modules/alb/aws
 
 Version: ~> 8.0
 
+==== [[module_cluster]] <<module_cluster,cluster>>
+
+Source: terraform-aws-modules/eks/aws
+
+Version: ~> 19.0
+
 === Resources
 
 The following resources are used by this module:
 
+- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_attachment[aws_autoscaling_attachment.node_groups_to_nlbs_target_groups] (resource)
 - https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record[aws_route53_record.wildcard] (resource)
 - https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster_auth[aws_eks_cluster_auth.cluster] (data source)
 - https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region[aws_region.current] (data source)
@@ -359,9 +360,9 @@ Description: Kubernetes API endpoint and CA certificate as a structured value.
 [cols="a,a,a",options="header,autowidth"]
 |===
 |Name |Source |Version
+|[[module_cluster]] <<module_cluster,cluster>> |terraform-aws-modules/eks/aws |~> 19.0
 |[[module_nlb]] <<module_nlb,nlb>> |terraform-aws-modules/alb/aws |~> 8.0
 |[[module_nlb_private]] <<module_nlb_private,nlb_private>> |terraform-aws-modules/alb/aws |~> 8.0
-|[[module_cluster]] <<module_cluster,cluster>> |terraform-aws-modules/eks/aws |~> 19.0
 |===
 
 = Resources
@@ -369,6 +370,7 @@ Description: Kubernetes API endpoint and CA certificate as a structured value.
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Type
+|https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_attachment[aws_autoscaling_attachment.node_groups_to_nlbs_target_groups] |resource
 |https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record[aws_route53_record.wildcard] |resource
 |https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster_auth[aws_eks_cluster_auth.cluster] |data source
 |https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region[aws_region.current] |data source

--- a/README.adoc
+++ b/README.adoc
@@ -81,17 +81,17 @@ The following providers are used by this module:
 
 The following Modules are called:
 
-==== [[module_cluster]] <<module_cluster,cluster>>
-
-Source: terraform-aws-modules/eks/aws
-
-Version: ~> 19.0
-
 ==== [[module_nlb]] <<module_nlb,nlb>>
 
 Source: terraform-aws-modules/alb/aws
 
 Version: ~> 8.0
+
+==== [[module_cluster]] <<module_cluster,cluster>>
+
+Source: terraform-aws-modules/eks/aws
+
+Version: ~> 19.0
 
 ==== [[module_nlb_private]] <<module_nlb_private,nlb_private>>
 
@@ -360,9 +360,9 @@ Description: Kubernetes API endpoint and CA certificate as a structured value.
 [cols="a,a,a",options="header,autowidth"]
 |===
 |Name |Source |Version
-|[[module_cluster]] <<module_cluster,cluster>> |terraform-aws-modules/eks/aws |~> 19.0
 |[[module_nlb]] <<module_nlb,nlb>> |terraform-aws-modules/alb/aws |~> 8.0
 |[[module_nlb_private]] <<module_nlb_private,nlb_private>> |terraform-aws-modules/alb/aws |~> 8.0
+|[[module_cluster]] <<module_cluster,cluster>> |terraform-aws-modules/eks/aws |~> 19.0
 |===
 
 = Resources

--- a/README.adoc
+++ b/README.adoc
@@ -81,17 +81,17 @@ The following providers are used by this module:
 
 The following Modules are called:
 
-==== [[module_nlb]] <<module_nlb,nlb>>
-
-Source: terraform-aws-modules/alb/aws
-
-Version: ~> 8.0
-
 ==== [[module_cluster]] <<module_cluster,cluster>>
 
 Source: terraform-aws-modules/eks/aws
 
 Version: ~> 19.0
+
+==== [[module_nlb]] <<module_nlb,nlb>>
+
+Source: terraform-aws-modules/alb/aws
+
+Version: ~> 8.0
 
 ==== [[module_nlb_private]] <<module_nlb_private,nlb_private>>
 

--- a/README.adoc
+++ b/README.adoc
@@ -87,17 +87,17 @@ Source: terraform-aws-modules/alb/aws
 
 Version: ~> 8.0
 
-==== [[module_nlb_private]] <<module_nlb_private,nlb_private>>
-
-Source: terraform-aws-modules/alb/aws
-
-Version: ~> 8.0
-
 ==== [[module_cluster]] <<module_cluster,cluster>>
 
 Source: terraform-aws-modules/eks/aws
 
 Version: ~> 19.0
+
+==== [[module_nlb_private]] <<module_nlb_private,nlb_private>>
+
+Source: terraform-aws-modules/alb/aws
+
+Version: ~> 8.0
 
 === Resources
 

--- a/lb.tf
+++ b/lb.tf
@@ -89,7 +89,7 @@ data "dns_a_record_set" "nlb" {
 
 locals {
   # List of Node_Groups names from the module configuration which have "nlbs_attachment = true" or undefined (true by default)
-  node_groups = [ for name,values in var.node_groups: name if lookup(values, "nlbs_attachment", false) ]
+  node_groups = [for name, values in var.node_groups : name if lookup(values, "nlbs_attachment", false)]
 
   # Map of "public" and/or "private" NLBs with their respective Target Groups ARNs
   nlbs_target_groups = merge(
@@ -98,12 +98,12 @@ locals {
   )
 
   # Map of all Autoscaling Groups created by EKS managed or Self managed Node Groups, referenced by the Node Group name
-  eks_managed_autoscaling_groups_by_node_group = { for item in setproduct(local.node_groups, module.cluster.eks_managed_node_groups_autoscaling_group_names): item[0] => item[1] if startswith(item[1], "eks-${item[0]}") }
-  self_managed_autoscaling_groups_by_node_group = { for item in setproduct(local.node_groups, module.cluster.self_managed_node_groups_autoscaling_group_names): item[0] => item[1] if startswith(item[1], item[0]) }
-  autoscaling_groups_by_node_group = merge( local.eks_managed_autoscaling_groups_by_node_group, local.self_managed_autoscaling_groups_by_node_group )
+  eks_managed_autoscaling_groups_by_node_group  = { for item in setproduct(local.node_groups, module.cluster.eks_managed_node_groups_autoscaling_group_names) : item[0] => item[1] if startswith(item[1], "eks-${item[0]}") }
+  self_managed_autoscaling_groups_by_node_group = { for item in setproduct(local.node_groups, module.cluster.self_managed_node_groups_autoscaling_group_names) : item[0] => item[1] if startswith(item[1], item[0]) }
+  autoscaling_groups_by_node_group              = merge(local.eks_managed_autoscaling_groups_by_node_group, local.self_managed_autoscaling_groups_by_node_group)
 
   # Map of all Autoscaling Groups to Target Groups attachments, with unique keys based only on data from module variables suitable for use in a for_each
-  autoscaling_attachments = { for item in setproduct(local.node_groups, keys(local.nlbs_target_groups), range(length(local.lb_target_groups))): "${item[0]}_${item[1]}_${local.lb_target_groups[item[2]].backend_port}" => { "autoscaling_group" = local.autoscaling_groups_by_node_group[item[0]], "target_group_arn" = local.nlbs_target_groups[item[1]][item[2]] } }
+  autoscaling_attachments = { for item in setproduct(local.node_groups, keys(local.nlbs_target_groups), range(length(local.lb_target_groups))) : "${item[0]}_${item[1]}_${local.lb_target_groups[item[2]].backend_port}" => { "autoscaling_group" = local.autoscaling_groups_by_node_group[item[0]], "target_group_arn" = local.nlbs_target_groups[item[1]][item[2]] } }
 }
 
 resource "aws_autoscaling_attachment" "node_groups_to_nlbs_target_groups" {

--- a/lb.tf
+++ b/lb.tf
@@ -88,21 +88,21 @@ data "dns_a_record_set" "nlb" {
 
 
 locals {
-  # List of Node_Groups names from the module configuration which have "nlbs_attachment = true" or undefined (true by default)
+  # List of node groups names from the module configuration which have "nlbs_attachment = true" or undefined (true by default)
   node_groups = [for name, values in var.node_groups : name if lookup(values, "nlbs_attachment", false)]
 
-  # Map of "public" and/or "private" NLBs with their respective Target Groups ARNs
+  # Map of "public" and/or "private" NLBs with their respective target group ARNs
   nlbs_target_groups = merge(
     var.create_public_nlb ? { "public" = module.nlb.target_group_arns } : {},
     var.create_private_nlb ? { "private" = module.nlb_private.target_group_arns } : {},
   )
 
-  # Map of all Autoscaling Groups created by EKS managed or Self managed Node Groups, referenced by the Node Group name
+  # Map of all autoscaling groups created by EKS managed or self-managed node groups, referenced by the node group name
   eks_managed_autoscaling_groups_by_node_group  = { for item in setproduct(local.node_groups, module.cluster.eks_managed_node_groups_autoscaling_group_names) : item[0] => item[1] if startswith(item[1], "eks-${item[0]}") }
   self_managed_autoscaling_groups_by_node_group = { for item in setproduct(local.node_groups, module.cluster.self_managed_node_groups_autoscaling_group_names) : item[0] => item[1] if startswith(item[1], item[0]) }
   autoscaling_groups_by_node_group              = merge(local.eks_managed_autoscaling_groups_by_node_group, local.self_managed_autoscaling_groups_by_node_group)
 
-  # Map of all Autoscaling Groups to Target Groups attachments, with unique keys based only on data from module variables suitable for use in a for_each
+  # Map of all autoscaling groups to target groups attachments, with unique keys based only on data from module variables suitable for use in a for_each
   autoscaling_attachments = { for item in setproduct(local.node_groups, keys(local.nlbs_target_groups), range(length(local.lb_target_groups))) : "${item[0]}_${item[1]}_${local.lb_target_groups[item[2]].backend_port}" => { "autoscaling_group" = local.autoscaling_groups_by_node_group[item[0]], "target_group_arn" = local.nlbs_target_groups[item[1]][item[2]] } }
 }
 

--- a/lb.tf
+++ b/lb.tf
@@ -88,7 +88,7 @@ data "dns_a_record_set" "nlb" {
 
 
 locals {
-  # List of node groups names from the module configuration which have "nlbs_attachment = true" or undefined (true by default)
+  # List of node groups names from the module configuration which have "nlbs_attachment = true"
   node_groups = [for name, values in var.node_groups : name if lookup(values, "nlbs_attachment", false)]
 
   # Map of "public" and/or "private" NLBs with their respective target group ARNs

--- a/main.tf
+++ b/main.tf
@@ -34,8 +34,8 @@ module "cluster" {
   aws_auth_roles    = var.aws_auth_roles
   aws_auth_users    = var.aws_auth_users
 
-  eks_managed_node_groups  = { for k,v in var.node_groups: k => v if ! var.use_self_managed_node_groups }
-  self_managed_node_groups = { for k,v in var.node_groups: k => v if var.use_self_managed_node_groups }
+  eks_managed_node_groups  = { for k, v in var.node_groups : k => v if !var.use_self_managed_node_groups }
+  self_managed_node_groups = { for k, v in var.node_groups : k => v if var.use_self_managed_node_groups }
 
   self_managed_node_group_defaults = {
     create_security_group = false

--- a/main.tf
+++ b/main.tf
@@ -34,8 +34,8 @@ module "cluster" {
   aws_auth_roles    = var.aws_auth_roles
   aws_auth_users    = var.aws_auth_users
 
-  eks_managed_node_groups  = var.use_self_managed_node_groups ? {} : var.node_groups
-  self_managed_node_groups = var.use_self_managed_node_groups ? var.node_groups : {}
+  eks_managed_node_groups  = { for k,v in var.node_groups: k => v if ! var.use_self_managed_node_groups }
+  self_managed_node_groups = { for k,v in var.node_groups: k => v if var.use_self_managed_node_groups }
 
   self_managed_node_group_defaults = {
     create_security_group = false


### PR DESCRIPTION
The `target_group_arns` argument doesn't exist on eks managed node group, so we need to handle the autoscaling groups attachment to NLBs in our module.

This commit uses a `nlbs_attachment` boolean argument of the node_groups to attach the related autoscaling group to the load balancers. This works for both types of node groups.
