### PR TITLE
feat: add a subdomain variable

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -81,6 +81,12 @@ The following providers are used by this module:
 
 The following Modules are called:
 
+==== [[module_cluster]] <<module_cluster,cluster>>
+
+Source: terraform-aws-modules/eks/aws
+
+Version: ~> 19.0
+
 ==== [[module_nlb]] <<module_nlb,nlb>>
 
 Source: terraform-aws-modules/alb/aws
@@ -92,12 +98,6 @@ Version: ~> 8.0
 Source: terraform-aws-modules/alb/aws
 
 Version: ~> 8.0
-
-==== [[module_cluster]] <<module_cluster,cluster>>
-
-Source: terraform-aws-modules/eks/aws
-
-Version: ~> 19.0
 
 === Resources
 

--- a/README.adoc
+++ b/README.adoc
@@ -371,8 +371,8 @@ Description: Kubernetes API endpoint and CA certificate as a structured value.
 [cols="a,a,a",options="header,autowidth"]
 |===
 |Name |Source |Version
-|[[module_cluster]] <<module_cluster,cluster>> |terraform-aws-modules/eks/aws |~> 19.0
 |[[module_nlb]] <<module_nlb,nlb>> |terraform-aws-modules/alb/aws |~> 8.0
+|[[module_cluster]] <<module_cluster,cluster>> |terraform-aws-modules/eks/aws |~> 19.0
 |[[module_nlb_private]] <<module_nlb_private,nlb_private>> |terraform-aws-modules/alb/aws |~> 8.0
 |===
 

--- a/README.adoc
+++ b/README.adoc
@@ -81,12 +81,6 @@ The following providers are used by this module:
 
 The following Modules are called:
 
-==== [[module_cluster]] <<module_cluster,cluster>>
-
-Source: terraform-aws-modules/eks/aws
-
-Version: ~> 19.0
-
 ==== [[module_nlb]] <<module_nlb,nlb>>
 
 Source: terraform-aws-modules/alb/aws
@@ -98,6 +92,12 @@ Version: ~> 8.0
 Source: terraform-aws-modules/alb/aws
 
 Version: ~> 8.0
+
+==== [[module_cluster]] <<module_cluster,cluster>>
+
+Source: terraform-aws-modules/eks/aws
+
+Version: ~> 19.0
 
 === Resources
 
@@ -149,7 +149,7 @@ Default: `null`
 
 ==== [[input_subdomain]] <<input_subdomain,subdomain>>
 
-Description: Sub domain of the cluster. Value used for the ingress' URL of the application.
+Description: The subdomain used for ingresses.
 
 Type: `string`
 
@@ -371,9 +371,9 @@ Description: Kubernetes API endpoint and CA certificate as a structured value.
 [cols="a,a,a",options="header,autowidth"]
 |===
 |Name |Source |Version
+|[[module_cluster]] <<module_cluster,cluster>> |terraform-aws-modules/eks/aws |~> 19.0
 |[[module_nlb]] <<module_nlb,nlb>> |terraform-aws-modules/alb/aws |~> 8.0
 |[[module_nlb_private]] <<module_nlb_private,nlb_private>> |terraform-aws-modules/alb/aws |~> 8.0
-|[[module_cluster]] <<module_cluster,cluster>> |terraform-aws-modules/eks/aws |~> 19.0
 |===
 
 = Resources
@@ -411,7 +411,7 @@ This module needs a Route 53 zone matching this variable with permission to crea
 |no
 
 |[[input_subdomain]] <<input_subdomain,subdomain>>
-|Sub domain of the cluster. Value used for the ingress' URL of the application.
+|The subdomain used for ingresses.
 |`string`
 |`"apps"`
 |no

--- a/README.adoc
+++ b/README.adoc
@@ -141,11 +141,19 @@ The following input variables are optional (have default values):
 
 Description: The base domain for the cluster.
 
-This module needs a Route 53 zone matching this variable with permission to create DNS records. It will create a wildcard CNAME record `*.apps.<base_domain>` that points to an Elastic Load Balancer routing ingress traffic to all cluster nodes. Such urls will be used by default by other DevOps Stack modules for the applications they deploy (e.g. Argo CD, Prometheus, etc).
+This module needs a Route 53 zone matching this variable with permission to create DNS records. It will create a wildcard CNAME record `*.<subdomain>.<base_domain>` that points to an Elastic Load Balancer routing ingress traffic to all cluster nodes. Such urls will be used by default by other DevOps Stack modules for the applications they deploy (e.g. Argo CD, Prometheus, etc).
 
 Type: `string`
 
 Default: `null`
+
+==== [[input_subdomain]] <<input_subdomain,subdomain>>
+
+Description: Sub domain of the cluster. Value used for the ingress' URL of the application.
+
+Type: `string`
+
+Default: `"apps"`
 
 ==== [[input_kubernetes_version]] <<input_kubernetes_version,kubernetes_version>>
 
@@ -396,10 +404,16 @@ Description: Kubernetes API endpoint and CA certificate as a structured value.
 |[[input_base_domain]] <<input_base_domain,base_domain>>
 |The base domain for the cluster.
 
-This module needs a Route 53 zone matching this variable with permission to create DNS records. It will create a wildcard CNAME record `*.apps.<base_domain>` that points to an Elastic Load Balancer routing ingress traffic to all cluster nodes. Such urls will be used by default by other DevOps Stack modules for the applications they deploy (e.g. Argo CD, Prometheus, etc).
+This module needs a Route 53 zone matching this variable with permission to create DNS records. It will create a wildcard CNAME record `*.<subdomain>.<base_domain>` that points to an Elastic Load Balancer routing ingress traffic to all cluster nodes. Such urls will be used by default by other DevOps Stack modules for the applications they deploy (e.g. Argo CD, Prometheus, etc).
 
 |`string`
 |`null`
+|no
+
+|[[input_subdomain]] <<input_subdomain,subdomain>>
+|Sub domain of the cluster. Value used for the ingress' URL of the application.
+|`string`
+|`"apps"`
 |no
 
 |[[input_kubernetes_version]] <<input_kubernetes_version,kubernetes_version>>

--- a/lb.tf
+++ b/lb.tf
@@ -74,7 +74,7 @@ resource "aws_route53_record" "wildcard" {
   count = var.base_domain != null && (var.create_public_nlb || var.create_private_nlb) ? 1 : 0
 
   zone_id = data.aws_route53_zone.this.0.id
-  name    = format("*.apps.%s", var.cluster_name)
+  name    = format("*.%s", trimprefix("${var.subdomain}.${var.cluster_name}", "."))
   type    = "CNAME"
   ttl     = "300"
   records = [

--- a/variables.tf
+++ b/variables.tf
@@ -14,7 +14,7 @@ variable "base_domain" {
 }
 
 variable "subdomain" {
-  description = "Sub domain of the cluster. Value used for the ingress' URL of the application."
+  description = "The subdomain used for ingresses."
   type        = string
   default     = "apps"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -17,6 +17,7 @@ variable "subdomain" {
   description = "The subdomain used for ingresses."
   type        = string
   default     = "apps"
+  nullable = false
 }
 
 variable "kubernetes_version" {

--- a/variables.tf
+++ b/variables.tf
@@ -17,7 +17,7 @@ variable "subdomain" {
   description = "The subdomain used for ingresses."
   type        = string
   default     = "apps"
-  nullable = false
+  nullable    = false
 }
 
 variable "kubernetes_version" {

--- a/variables.tf
+++ b/variables.tf
@@ -7,10 +7,16 @@ variable "base_domain" {
   description = <<-EOT
     The base domain for the cluster.
 
-    This module needs a Route 53 zone matching this variable with permission to create DNS records. It will create a wildcard CNAME record `*.apps.<base_domain>` that points to an Elastic Load Balancer routing ingress traffic to all cluster nodes. Such urls will be used by default by other DevOps Stack modules for the applications they deploy (e.g. Argo CD, Prometheus, etc).
+    This module needs a Route 53 zone matching this variable with permission to create DNS records. It will create a wildcard CNAME record `*.<subdomain>.<base_domain>` that points to an Elastic Load Balancer routing ingress traffic to all cluster nodes. Such urls will be used by default by other DevOps Stack modules for the applications they deploy (e.g. Argo CD, Prometheus, etc).
   EOT
   type        = string
   default     = null
+}
+
+variable "subdomain" {
+  description = "Sub domain of the cluster. Value used for the ingress' URL of the application."
+  type        = string
+  default     = "apps"
 }
 
 variable "kubernetes_version" {


### PR DESCRIPTION
## Description of the changes

Hello,

We have a need to use URLs without the .apps. part, in order to achieve that without introducing a breaking change we propose a new variable subdomain that defaults to apps, that way we can set it to an empty string on our side.

## Breaking change

- [X] No

## Tests executed on which distribution(s)

- [X] EKS (AWS)