### PR TITLE
fix: node_groups output value

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -81,12 +81,6 @@ The following providers are used by this module:
 
 The following Modules are called:
 
-==== [[module_cluster]] <<module_cluster,cluster>>
-
-Source: terraform-aws-modules/eks/aws
-
-Version: ~> 19.0
-
 ==== [[module_nlb]] <<module_nlb,nlb>>
 
 Source: terraform-aws-modules/alb/aws
@@ -98,6 +92,12 @@ Version: ~> 8.0
 Source: terraform-aws-modules/alb/aws
 
 Version: ~> 8.0
+
+==== [[module_cluster]] <<module_cluster,cluster>>
+
+Source: terraform-aws-modules/eks/aws
+
+Version: ~> 19.0
 
 === Resources
 
@@ -363,9 +363,9 @@ Description: Kubernetes API endpoint and CA certificate as a structured value.
 [cols="a,a,a",options="header,autowidth"]
 |===
 |Name |Source |Version
+|[[module_cluster]] <<module_cluster,cluster>> |terraform-aws-modules/eks/aws |~> 19.0
 |[[module_nlb]] <<module_nlb,nlb>> |terraform-aws-modules/alb/aws |~> 8.0
 |[[module_nlb_private]] <<module_nlb_private,nlb_private>> |terraform-aws-modules/alb/aws |~> 8.0
-|[[module_cluster]] <<module_cluster,cluster>> |terraform-aws-modules/eks/aws |~> 19.0
 |===
 
 = Resources

--- a/outputs.tf
+++ b/outputs.tf
@@ -20,7 +20,10 @@ output "node_security_group_id" {
 
 output "node_groups" {
   description = "Map of attribute maps for all node groups created."
-  value       = module.cluster.self_managed_node_groups
+  value       = merge(
+                  module.cluster.eks_managed_node_groups,
+                  module.cluster.self_managed_node_groups,
+                )
 }
 
 output "kubernetes_host" {


### PR DESCRIPTION
## Description of the changes

The output was value was not correctly set when `use_self_managed_node_groups` was set to `false` (the default value).