### PR TITLE
feat: add cluster ARN as output

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -3,6 +3,11 @@ output "cluster_name" {
   value       = var.cluster_name
 }
 
+output "cluster_arn" {
+  description = "The Amazon Resource Name (ARN) of the cluster"
+  value       = module.cluster.cluster_arn
+}
+
 output "base_domain" {
   description = "The base domain for the cluster."
   value       = local.base_domain


### PR DESCRIPTION
## Description of the changes

This PR add an output to be able to retrieve the cluster ARN. This can be usefull for configuration of auth for example.

## Breaking change

- [x] No
- [ ] Yes
