### PR TITLE
Update eks module to v20

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -73,13 +73,19 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
-- [[provider_aws]] <<provider_aws,aws>> (>= 4)
-
 - [[provider_dns]] <<provider_dns,dns>>
+
+- [[provider_aws]] <<provider_aws,aws>> (>= 4)
 
 === Modules
 
 The following Modules are called:
+
+==== [[module_cluster]] <<module_cluster,cluster>>
+
+Source: terraform-aws-modules/eks/aws
+
+Version: ~> 20.0
 
 ==== [[module_nlb]] <<module_nlb,nlb>>
 
@@ -92,12 +98,6 @@ Version: ~> 8.0
 Source: terraform-aws-modules/alb/aws
 
 Version: ~> 8.0
-
-==== [[module_cluster]] <<module_cluster,cluster>>
-
-Source: terraform-aws-modules/eks/aws
-
-Version: ~> 19.0
 
 === Resources
 
@@ -191,46 +191,6 @@ Type: `list(string)`
 
 Default: `[]`
 
-==== [[input_aws_auth_accounts]] <<input_aws_auth_accounts,aws_auth_accounts>>
-
-Description: Additional AWS account numbers to add to the aws-auth configmap.
-
-Type: `list(string)`
-
-Default: `[]`
-
-==== [[input_aws_auth_roles]] <<input_aws_auth_roles,aws_auth_roles>>
-
-Description: Additional IAM roles to add to the aws-auth configmap.
-
-Type:
-[source,hcl]
-----
-list(object({
-    rolearn  = string
-    username = string
-    groups   = list(string)
-  }))
-----
-
-Default: `[]`
-
-==== [[input_aws_auth_users]] <<input_aws_auth_users,aws_auth_users>>
-
-Description: Additional IAM users to add to the aws-auth configmap.
-
-Type:
-[source,hcl]
-----
-list(object({
-    userarn  = string
-    username = string
-    groups   = list(string)
-  }))
-----
-
-Default: `[]`
-
 ==== [[input_node_groups]] <<input_node_groups,node_groups>>
 
 Description: A map of node group configurations to be created.
@@ -296,6 +256,14 @@ A list of maps describing the HTTP listeners. Required key/values: `port`, `prot
 Type: `list(any)`
 
 Default: `[]`
+
+==== [[input_tags]] <<input_tags,tags>>
+
+Description: Tags to apply to all resources created by the EKS Terraform module.
+
+Type: `map(string)`
+
+Default: `{}`
 
 === Outputs
 
@@ -383,9 +351,9 @@ Description: Kubernetes API endpoint and CA certificate as a structured value.
 [cols="a,a,a",options="header,autowidth"]
 |===
 |Name |Source |Version
-|[[module_cluster]] <<module_cluster,cluster>> |terraform-aws-modules/eks/aws |~> 19.0
 |[[module_nlb]] <<module_nlb,nlb>> |terraform-aws-modules/alb/aws |~> 8.0
 |[[module_nlb_private]] <<module_nlb_private,nlb_private>> |terraform-aws-modules/alb/aws |~> 8.0
+|[[module_cluster]] <<module_cluster,cluster>> |terraform-aws-modules/eks/aws |~> 20.0
 |===
 
 = Resources
@@ -473,44 +441,6 @@ The value can be set and increased on an existing cluster to upgrade it. *Note t
 |`[]`
 |no
 
-|[[input_aws_auth_accounts]] <<input_aws_auth_accounts,aws_auth_accounts>>
-|Additional AWS account numbers to add to the aws-auth configmap.
-|`list(string)`
-|`[]`
-|no
-
-|[[input_aws_auth_roles]] <<input_aws_auth_roles,aws_auth_roles>>
-|Additional IAM roles to add to the aws-auth configmap.
-|
-
-[source]
-----
-list(object({
-    rolearn  = string
-    username = string
-    groups   = list(string)
-  }))
-----
-
-|`[]`
-|no
-
-|[[input_aws_auth_users]] <<input_aws_auth_users,aws_auth_users>>
-|Additional IAM users to add to the aws-auth configmap.
-|
-
-[source]
-----
-list(object({
-    userarn  = string
-    username = string
-    groups   = list(string)
-  }))
-----
-
-|`[]`
-|no
-
 |[[input_node_groups]] <<input_node_groups,node_groups>>
 |A map of node group configurations to be created.
 |`any`
@@ -564,6 +494,12 @@ A list of maps describing the HTTP listeners. Required key/values: `port`, `prot
 
 |`list(any)`
 |`[]`
+|no
+
+|[[input_tags]] <<input_tags,tags>>
+|Tags to apply to all resources created by the EKS Terraform module.
+|`map(string)`
+|`{}`
 |no
 
 |===

--- a/main.tf
+++ b/main.tf
@@ -85,4 +85,5 @@ module "cluster" {
       ipv6_cidr_blocks = ["::/0"]
     }
   }
+  tags = var.tags
 }

--- a/main.tf
+++ b/main.tf
@@ -13,7 +13,7 @@ data "aws_eks_cluster_auth" "cluster" {
 module "cluster" {
   source = "terraform-aws-modules/eks/aws"
 
-  version = "~> 19.0"
+  version = "~> 20.0"
 
   cluster_name    = var.cluster_name
   cluster_version = var.kubernetes_version

--- a/main.tf
+++ b/main.tf
@@ -27,13 +27,6 @@ module "cluster" {
   subnet_ids  = var.private_subnet_ids
   enable_irsa = true
 
-  create_aws_auth_configmap = var.use_self_managed_node_groups
-  manage_aws_auth_configmap = true
-
-  aws_auth_accounts = var.aws_auth_accounts
-  aws_auth_roles    = var.aws_auth_roles
-  aws_auth_users    = var.aws_auth_users
-
   eks_managed_node_groups  = { for k, v in var.node_groups : k => v if !var.use_self_managed_node_groups }
   self_managed_node_groups = { for k, v in var.node_groups : k => v if var.use_self_managed_node_groups }
 

--- a/variables.tf
+++ b/variables.tf
@@ -56,32 +56,6 @@ variable "public_subnet_ids" {
   default     = []
 }
 
-variable "aws_auth_accounts" {
-  description = "Additional AWS account numbers to add to the aws-auth configmap."
-  type        = list(string)
-  default     = []
-}
-
-variable "aws_auth_roles" {
-  description = "Additional IAM roles to add to the aws-auth configmap."
-  type = list(object({
-    rolearn  = string
-    username = string
-    groups   = list(string)
-  }))
-  default = []
-}
-
-variable "aws_auth_users" {
-  description = "Additional IAM users to add to the aws-auth configmap."
-  type = list(object({
-    userarn  = string
-    username = string
-    groups   = list(string)
-  }))
-  default = []
-}
-
 variable "node_groups" {
   description = "A map of node group configurations to be created."
   type        = any

--- a/variables.tf
+++ b/variables.tf
@@ -113,3 +113,9 @@ variable "extra_lb_http_tcp_listeners" {
   type        = list(any)
   default     = []
 }
+
+variable "tags" {
+  description = "Tags to apply to all resources created by the EKS Terraform module."
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
## Description of the changes

Aws offer a new mechanism to manage auth : access entries. Upgrading to V20 of the eks module is mandatory.

## Breaking change 🤷

- [ ] No
- [x] Yes

* Replace the use of aws-auth configmap with EKS cluster access entry ([#2858](https://github.com/terraform-aws-modules/terraform-aws-eks/pull/2858))