### PR TITLE
feat: add outputs nlb dns

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -81,12 +81,6 @@ The following providers are used by this module:
 
 The following Modules are called:
 
-==== [[module_cluster]] <<module_cluster,cluster>>
-
-Source: terraform-aws-modules/eks/aws
-
-Version: ~> 19.0
-
 ==== [[module_nlb]] <<module_nlb,nlb>>
 
 Source: terraform-aws-modules/alb/aws
@@ -98,6 +92,12 @@ Version: ~> 8.0
 Source: terraform-aws-modules/alb/aws
 
 Version: ~> 8.0
+
+==== [[module_cluster]] <<module_cluster,cluster>>
+
+Source: terraform-aws-modules/eks/aws
+
+Version: ~> 19.0
 
 === Resources
 
@@ -339,11 +339,11 @@ Description: Token to use to authenticate with the cluster.
 
 ==== [[output_nlb_dns_name]] <<output_nlb_dns_name,nlb_dns_name>>
 
-Description: Map of the DNS name of the load balancer (public and/or private if enabled).
+Description: Map of the DNS names of the load balancers (public and/or private if enabled). Returns `null` if the respective load balancer is disabled.
 
 ==== [[output_nlb_zone_id]] <<output_nlb_zone_id,nlb_zone_id>>
 
-Description: Map of the zone_id of the load balancer to assist with creating DNS records (public and/or private if enabled).
+Description: Map of the zone_id of the load balancer to assist with creating DNS records (public and/or private if enabled). Returns `null` if the respective load balancer is disabled.
 
 ==== [[output_nlb_target_groups]] <<output_nlb_target_groups,nlb_target_groups>>
 
@@ -582,8 +582,8 @@ A list of maps describing the HTTP listeners. Required key/values: `port`, `prot
 |[[output_kubernetes_host]] <<output_kubernetes_host,kubernetes_host>> |Endpoint for your Kubernetes API server.
 |[[output_kubernetes_cluster_ca_certificate]] <<output_kubernetes_cluster_ca_certificate,kubernetes_cluster_ca_certificate>> |Certificate data required to communicate with the cluster.
 |[[output_kubernetes_token]] <<output_kubernetes_token,kubernetes_token>> |Token to use to authenticate with the cluster.
-|[[output_nlb_dns_name]] <<output_nlb_dns_name,nlb_dns_name>> |Map of the DNS name of the load balancer (public and/or private if enabled).
-|[[output_nlb_zone_id]] <<output_nlb_zone_id,nlb_zone_id>> |Map of the zone_id of the load balancer to assist with creating DNS records (public and/or private if enabled).
+|[[output_nlb_dns_name]] <<output_nlb_dns_name,nlb_dns_name>> |Map of the DNS names of the load balancers (public and/or private if enabled). Returns `null` if the respective load balancer is disabled.
+|[[output_nlb_zone_id]] <<output_nlb_zone_id,nlb_zone_id>> |Map of the zone_id of the load balancer to assist with creating DNS records (public and/or private if enabled). Returns `null` if the respective load balancer is disabled.
 |[[output_nlb_target_groups]] <<output_nlb_target_groups,nlb_target_groups>> |List of the target groups ARNs (public and/or private if enabled).
 |[[output_kubernetes]] <<output_kubernetes,kubernetes>> |Kubernetes API endpoint and CA certificate as a structured value.
 |===

--- a/README.adoc
+++ b/README.adoc
@@ -73,25 +73,25 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
-- [[provider_dns]] <<provider_dns,dns>>
-
 - [[provider_aws]] <<provider_aws,aws>> (>= 4)
+
+- [[provider_dns]] <<provider_dns,dns>>
 
 === Modules
 
 The following Modules are called:
-
-==== [[module_nlb]] <<module_nlb,nlb>>
-
-Source: terraform-aws-modules/alb/aws
-
-Version: ~> 8.0
 
 ==== [[module_cluster]] <<module_cluster,cluster>>
 
 Source: terraform-aws-modules/eks/aws
 
 Version: ~> 19.0
+
+==== [[module_nlb]] <<module_nlb,nlb>>
+
+Source: terraform-aws-modules/alb/aws
+
+Version: ~> 8.0
 
 ==== [[module_nlb_private]] <<module_nlb_private,nlb_private>>
 
@@ -337,9 +337,17 @@ Description: Certificate data required to communicate with the cluster.
 
 Description: Token to use to authenticate with the cluster.
 
+==== [[output_nlb_dns_name]] <<output_nlb_dns_name,nlb_dns_name>>
+
+Description: Map of the DNS name of the load balancer (public and/or private if enabled).
+
+==== [[output_nlb_zone_id]] <<output_nlb_zone_id,nlb_zone_id>>
+
+Description: Map of the zone_id of the load balancer to assist with creating DNS records (public and/or private if enabled).
+
 ==== [[output_nlb_target_groups]] <<output_nlb_target_groups,nlb_target_groups>>
 
-Description: List of ARNs of Network LBs (public and/or private if enabled).
+Description: List of the target groups ARNs (public and/or private if enabled).
 
 ==== [[output_kubernetes]] <<output_kubernetes,kubernetes>>
 
@@ -366,8 +374,8 @@ Description: Kubernetes API endpoint and CA certificate as a structured value.
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
-|[[provider_dns]] <<provider_dns,dns>> |n/a
 |[[provider_aws]] <<provider_aws,aws>> |>= 4
+|[[provider_dns]] <<provider_dns,dns>> |n/a
 |===
 
 = Modules
@@ -574,7 +582,9 @@ A list of maps describing the HTTP listeners. Required key/values: `port`, `prot
 |[[output_kubernetes_host]] <<output_kubernetes_host,kubernetes_host>> |Endpoint for your Kubernetes API server.
 |[[output_kubernetes_cluster_ca_certificate]] <<output_kubernetes_cluster_ca_certificate,kubernetes_cluster_ca_certificate>> |Certificate data required to communicate with the cluster.
 |[[output_kubernetes_token]] <<output_kubernetes_token,kubernetes_token>> |Token to use to authenticate with the cluster.
-|[[output_nlb_target_groups]] <<output_nlb_target_groups,nlb_target_groups>> |List of ARNs of Network LBs (public and/or private if enabled).
+|[[output_nlb_dns_name]] <<output_nlb_dns_name,nlb_dns_name>> |Map of the DNS name of the load balancer (public and/or private if enabled).
+|[[output_nlb_zone_id]] <<output_nlb_zone_id,nlb_zone_id>> |Map of the zone_id of the load balancer to assist with creating DNS records (public and/or private if enabled).
+|[[output_nlb_target_groups]] <<output_nlb_target_groups,nlb_target_groups>> |List of the target groups ARNs (public and/or private if enabled).
 |[[output_kubernetes]] <<output_kubernetes,kubernetes>> |Kubernetes API endpoint and CA certificate as a structured value.
 |===
 // END_TF_TABLES

--- a/outputs.tf
+++ b/outputs.tf
@@ -63,7 +63,7 @@ output "nlb_zone_id" {
 }
 
 output "nlb_target_groups" {
-  description = "List of ARNs of Network LBs (public and/or private if enabled)."
+  description = "List of the target groups ARNs (public and/or private if enabled)."
   value       = concat(module.nlb.target_group_arns, module.nlb_private.target_group_arns)
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -46,6 +46,22 @@ output "kubernetes_token" {
   value       = data.aws_eks_cluster_auth.cluster.token
 }
 
+output "nlb_dns_name" {
+  description = "Map of the DNS names of the load balancers (public and/or private if enabled). Returns `null` if the respective load balancer is disabled."
+  value = {
+    public  = module.nlb.lb_dns_name
+    private = module.nlb_private.lb_dns_name
+  }
+}
+
+output "nlb_zone_id" {
+  description = "Map of the zone_id of the load balancer to assist with creating DNS records (public and/or private if enabled). Returns `null` if the respective load balancer is disabled."
+  value = {
+    public  = module.nlb.lb_zone_id
+    private = module.nlb_private.lb_zone_id
+  }
+}
+
 output "nlb_target_groups" {
   description = "List of ARNs of Network LBs (public and/or private if enabled)."
   value       = concat(module.nlb.target_group_arns, module.nlb_private.target_group_arns)

--- a/outputs.tf
+++ b/outputs.tf
@@ -25,10 +25,10 @@ output "node_security_group_id" {
 
 output "node_groups" {
   description = "Map of attribute maps for all node groups created."
-  value       = merge(
-                  module.cluster.eks_managed_node_groups,
-                  module.cluster.self_managed_node_groups,
-                )
+  value = merge(
+    module.cluster.eks_managed_node_groups,
+    module.cluster.self_managed_node_groups,
+  )
 }
 
 output "kubernetes_host" {


### PR DESCRIPTION
## Description of the changes

In order to be able to create alias records pointing to AWS resources we need the dns name and zone_id of the Netwok Load Balancers.

Tested locally with :

```
resource "aws_route53_record" "app2" {
  zone_id = data.aws_route53_zone.this.zone_id

  name = "app2"
  type = "A"

  alias {
    name                   = module.cluster_red.nlb_dns_name["public"]
    zone_id                = module.cluster_red.nlb_zone_id["public"]
    evaluate_target_health = true
  }
}
```

Ps: I also changed the description for nlb_target_group after I tried to user it to have the NLB ARNs like it said..

## Breaking change

- [X] No
- [ ] Yes
