### PR TITLE
fix: enable administrator access to the cluster creator

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -281,6 +281,14 @@ Default:
 ]
 ----
 
+==== [[input_access_entries]] <<input_access_entries,access_entries>>
+
+Description: Map of access entries to add to the cluster. The type of the variable is `any` similarly to the upstream EKS module. Please check the https://github.com/terraform-aws-modules/terraform-aws-eks[their README] for more information and examples.
+
+Type: `any`
+
+Default: `{}`
+
 === Outputs
 
 The following outputs are exported:
@@ -532,6 +540,12 @@ A list of maps describing the HTTP listeners. Required key/values: `port`, `prot
 ]
 ----
 
+|no
+
+|[[input_access_entries]] <<input_access_entries,access_entries>>
+|Map of access entries to add to the cluster. The type of the variable is `any` similarly to the upstream EKS module. Please check the https://github.com/terraform-aws-modules/terraform-aws-eks[their README] for more information and examples.
+|`any`
+|`{}`
 |no
 
 |===

--- a/main.tf
+++ b/main.tf
@@ -25,6 +25,12 @@ module "cluster" {
 
   cluster_enabled_log_types = var.cluster_enabled_log_types
 
+  # The creator of the cluster tipically is the Terraform API user. This user is then used to also install the bootstrap
+  # Argo CD through Helm, so it needs to access the Kubernetes cluster directly. As such, we hardcode the following
+  # variable to always be true.
+  enable_cluster_creator_admin_permissions = true
+
+
   vpc_id      = var.vpc_id
   subnet_ids  = var.private_subnet_ids
   enable_irsa = true

--- a/main.tf
+++ b/main.tf
@@ -30,6 +30,8 @@ module "cluster" {
   # variable to always be true.
   enable_cluster_creator_admin_permissions = true
 
+  # Extra API users with administrator access to the EKS cluster.
+  access_entries = var.access_entries
 
   vpc_id      = var.vpc_id
   subnet_ids  = var.private_subnet_ids
@@ -93,5 +95,6 @@ module "cluster" {
       ipv6_cidr_blocks = ["::/0"]
     }
   }
+
   tags = var.tags
 }

--- a/variables.tf
+++ b/variables.tf
@@ -125,3 +125,9 @@ variable "cluster_enabled_log_types" {
   type        = list(string)
   default     = ["audit", "api", "authenticator"]
 }
+
+variable "access_entries" {
+  description = "Map of access entries to add to the cluster. The type of the variable is `any` similarly to the upstream EKS module. Please check the https://github.com/terraform-aws-modules/terraform-aws-eks[their README] for more information and examples."
+  type        = any
+  default     = {}
+}


### PR DESCRIPTION
## Description of the changes

In the upgrade to v20 of the EKS Terraform module we missed that we should have enabled the variable `enable_cluster_creator_admin_permissions`, otherwise, Terraform won't be able to continue to bootstrap the cluster because it is unable to access it.

I've also added a new variable to add other ARN principals with access to the cluster.

## Breaking change

- [x] No
- [ ] Yes
