### PR TITLE
feat: add cluster_addons input variable

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -58,9 +58,9 @@ When going from self-managed node groups to EKS managed ones, note the following
 
 Switching an existing cluster to EKS managed node groups is possible, but requires manually draining the existing nodes after the new node group is created and before the old one is destroyed (by doing a `terraform apply -target <resource>` in multiple steps).
 
-== Managing addons
+== Managing add-ons
 
-You can use the `cluster_addons` variable to manage EKS addons on the cluster. The key of the map can be the addon name or set with the `name` attribute. The value is a map of the addon configuration. Here is a minimum example:
+You can use the `cluster_addons` variable to manage EKS add-ons on the cluster. The key of the map can be the add-on name or set with the `name` attribute. The value is a map of the add-on configuration. Here is a minimum example:
 
 [source.hcl]
 ----
@@ -97,11 +97,9 @@ module "cluster_green" {
 }
 ----
 
-TIP: Be careful when using the pod identity agent, it binds the port 80 on the hosts so its not available anymore.
+TIP: Be careful when using the pod identity agent, it binds the port 80 on the hosts so it is not available anymore.
 
-Check the  https://github.com/terraform-aws-modules/terraform-aws-eks?tab=readme-ov-file#input_cluster_addons[upstream module documentation] for more information. And the https://docs.aws.amazon.com/eks/latest/userguide/workloads-add-ons-available-eks.html[AWS EKS documentation] for the list of available addons.
-
-
+Check the  https://github.com/terraform-aws-modules/terraform-aws-eks?tab=readme-ov-file#input_cluster_addons[upstream module documentation] for more information. And the https://docs.aws.amazon.com/eks/latest/userguide/workloads-add-ons-available-eks.html[AWS EKS documentation] for the list of available add-ons.
 
 == Technical Reference
 

--- a/README.adoc
+++ b/README.adoc
@@ -58,6 +58,51 @@ When going from self-managed node groups to EKS managed ones, note the following
 
 Switching an existing cluster to EKS managed node groups is possible, but requires manually draining the existing nodes after the new node group is created and before the old one is destroyed (by doing a `terraform apply -target <resource>` in multiple steps).
 
+== Managing addons
+
+You can use the `cluster_addons` variable to manage EKS addons on the cluster. The key of the map can be the addon name or set with the `name` attribute. The value is a map of the addon configuration. Here is a minimum example:
+
+[source.hcl]
+----
+data "aws_iam_policy" "cni" {
+  name = "AmazonEKS_CNI_Policy"
+}
+
+resource "aws_iam_role" "vpc_cni" {
+  name               = "vpc-cni-role"
+  assume_role_policy = data.aws_iam_policy_document.pod_identity_association.json
+}
+
+resource "aws_iam_role_policy_attachment" "vpc_cni" {
+  role       = aws_iam_role.vpc_cni.name
+  policy_arn = data.aws_iam_policy.cni.arn
+}
+
+module "cluster_green" {
+  source = "git::https://github.com/camptocamp/devops-stack-module-cluster-eks.git?ref=v4.x.x"
+
+  [...]
+
+  cluster_addons = {
+    coredns                = {}
+    eks-pod-identity-agent = {}
+    kube-proxy             = {}
+    vpc-cni = {
+      pod_identity_association = [{
+        role_arn        = aws_iam_role.vpc_cni.arn
+        service_account = "aws-node"
+      }]
+    }
+  }
+}
+----
+
+TIP: Be careful when using the pod identity agent, it binds the port 80 on the hosts so its not available anymore.
+
+Check the  https://github.com/terraform-aws-modules/terraform-aws-eks?tab=readme-ov-file#input_cluster_addons[upstream module documentation] for more information. And the https://docs.aws.amazon.com/eks/latest/userguide/workloads-add-ons-available-eks.html[AWS EKS documentation] for the list of available addons.
+
+
+
 == Technical Reference
 
 // BEGIN_TF_DOCS
@@ -346,7 +391,7 @@ Description: List of the target groups ARNs (public and/or private if enabled).
 Description: Kubernetes API endpoint and CA certificate as a structured value.
 // END_TF_DOCS
 
-=== Reference in table format 
+=== Reference in table format
 
 .Show tables
 [%collapsible]

--- a/README.adoc
+++ b/README.adoc
@@ -334,6 +334,14 @@ Type: `any`
 
 Default: `{}`
 
+==== [[input_cluster_addons]] <<input_cluster_addons,cluster_addons>>
+
+Description: Map of cluster add-on configurations to enable for the cluster. Add-on name can be the map keys or set with `name`.
+
+Type: `any`
+
+Default: `{}`
+
 === Outputs
 
 The following outputs are exported:
@@ -420,8 +428,8 @@ Description: Kubernetes API endpoint and CA certificate as a structured value.
 [cols="a,a,a",options="header,autowidth"]
 |===
 |Name |Source |Version
-|[[module_cluster]] <<module_cluster,cluster>> |terraform-aws-modules/eks/aws |~> 20.0
 |[[module_nlb]] <<module_nlb,nlb>> |terraform-aws-modules/alb/aws |~> 8.0
+|[[module_cluster]] <<module_cluster,cluster>> |terraform-aws-modules/eks/aws |~> 20.0
 |[[module_nlb_private]] <<module_nlb_private,nlb_private>> |terraform-aws-modules/alb/aws |~> 8.0
 |===
 
@@ -589,6 +597,12 @@ A list of maps describing the HTTP listeners. Required key/values: `port`, `prot
 
 |[[input_access_entries]] <<input_access_entries,access_entries>>
 |Map of access entries to add to the cluster. The type of the variable is `any` similarly to the upstream EKS module. Please check the https://github.com/terraform-aws-modules/terraform-aws-eks[their README] for more information and examples.
+|`any`
+|`{}`
+|no
+
+|[[input_cluster_addons]] <<input_cluster_addons,cluster_addons>>
+|Map of cluster add-on configurations to enable for the cluster. Add-on name can be the map keys or set with `name`.
 |`any`
 |`{}`
 |no

--- a/README.adoc
+++ b/README.adoc
@@ -417,8 +417,8 @@ Description: Kubernetes API endpoint and CA certificate as a structured value.
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
-|[[provider_aws]] <<provider_aws,aws>> |>= 4
 |[[provider_dns]] <<provider_dns,dns>> |n/a
+|[[provider_aws]] <<provider_aws,aws>> |>= 4
 |===
 
 = Modules
@@ -426,8 +426,8 @@ Description: Kubernetes API endpoint and CA certificate as a structured value.
 [cols="a,a,a",options="header,autowidth"]
 |===
 |Name |Source |Version
-|[[module_nlb]] <<module_nlb,nlb>> |terraform-aws-modules/alb/aws |~> 8.0
 |[[module_cluster]] <<module_cluster,cluster>> |terraform-aws-modules/eks/aws |~> 20.0
+|[[module_nlb]] <<module_nlb,nlb>> |terraform-aws-modules/alb/aws |~> 8.0
 |[[module_nlb_private]] <<module_nlb_private,nlb_private>> |terraform-aws-modules/alb/aws |~> 8.0
 |===
 

--- a/main.tf
+++ b/main.tf
@@ -33,6 +33,8 @@ module "cluster" {
   # Extra API users with administrator access to the EKS cluster.
   access_entries = var.access_entries
 
+  cluster_addons = var.cluster_addons
+
   vpc_id      = var.vpc_id
   subnet_ids  = var.private_subnet_ids
   enable_irsa = true

--- a/variables.tf
+++ b/variables.tf
@@ -131,3 +131,9 @@ variable "access_entries" {
   type        = any
   default     = {}
 }
+
+variable "cluster_addons" {
+  description = "Map of cluster add-on configurations to enable for the cluster. Add-on name can be the map keys or set with `name`."
+  type        = any
+  default     = {}
+}


### PR DESCRIPTION
## Description of the changes

Add optional variable cluster_addons to manage EKS eddons, that way we can if we want not use the efs and ebs modules.

Here are examples that worked for me :

### Minimum addons:

```
data "aws_iam_policy" "cni" {
  name = "AmazonEKS_CNI_Policy"
}

resource "aws_iam_role" "vpc_cni" {
  name               = "vpc-cni-role"
  assume_role_policy = data.aws_iam_policy_document.pod_identity_association.json
}

resource "aws_iam_role_policy_attachment" "vpc_cni" {
  role       = aws_iam_role.vpc_cni.name
  policy_arn = data.aws_iam_policy.cni.arn
}

module "cluster_green" {
  source = "git::https://github.com/camptocamp/devops-stack-module-cluster-eks.git?ref=v4.x.x"

  [...]

  cluster_addons = {
    coredns                = {}
    eks-pod-identity-agent = {}
    kube-proxy             = {}
    vpc-cni = {
      pod_identity_association = [{
        role_arn        = aws_iam_role.vpc_cni.arn
        service_account = "aws-node"
      }]
    }
  }
}
```

### With EBS and EFS support:

```
locals {
  addons_policies = {
    vpc_cni        = "AmazonEKS_CNI_Policy"
    ebs_csi_driver = "AmazonEBSCSIDriverPolicy"
    efs_csi_driver = "AmazonEFSCSIDriverPolicy"
  }
}

data "aws_iam_policy" "eks_addon" {
  for_each = local.addons_policies
  name     = each.value
}

resource "aws_iam_role" "eks_addon" {
  for_each = local.addons_policies

  name               = "eks-addon-${replace(each.key, "_", "-")}"
  assume_role_policy = data.aws_iam_policy_document.pod_identity_association.json
}

resource "aws_iam_role_policy_attachment" "eks_addon" {
  for_each = local.addons_policies

  role       = aws_iam_role.eks_addon[each.key].name
  policy_arn = data.aws_iam_policy.eks_addon[each.key].arn
}

module "cluster_green" {
  source = "git::https://github.com/camptocamp/devops-stack-module-cluster-eks.git?ref=v4.x.x"

  [...]

  cluster_addons = {
    coredns                = {}
    eks-pod-identity-agent = {}
    kube-proxy             = {}
    vpc-cni = {
      pod_identity_association = [{
        role_arn        = aws_iam_role.eks_addon["vpc_cni"].arn
        service_account = "aws-node"
      }]
    }
    aws-ebs-csi-driver = {
      pod_identity_association = [{
        role_arn        = aws_iam_role.eks_addon["ebs_csi_driver"].arn
        service_account = "ebs-csi-controller-sa"
      }]
    }
    aws-efs-csi-driver = {
      pod_identity_association = [{
        role_arn        = aws_iam_role.eks_addon["efs_csi_driver"].arn
        service_account = "efs-csi-controller-sa"
      }]
    }
  }
}
```


## Breaking change

- [X] No
- [ ] Yes

