### PR TITLE
feat: add enable_cluster_creator_admin_permissions variable

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -333,6 +333,14 @@ Default:
 ]
 ----
 
+==== [[input_enable_cluster_creator_admin_permissions]] <<input_enable_cluster_creator_admin_permissions,enable_cluster_creator_admin_permissions>>
+
+Description: Add the current caller identity (tipycally the Terraform API user) as a cluster administrator via access entry. This is needed to also install the bootstrap Argo CD through Helm. Default to `true`. Set to `false` to manage all access entries with the `access_entries` argument.
+
+Type: `bool`
+
+Default: `true`
+
 ==== [[input_access_entries]] <<input_access_entries,access_entries>>
 
 Description: Map of access entries to add to the cluster. The type of the variable is `any` similarly to the upstream EKS module. Please check the https://github.com/terraform-aws-modules/terraform-aws-eks[their README] for more information and examples.
@@ -611,6 +619,12 @@ A list of maps describing the HTTP listeners. Required key/values: `port`, `prot
 ]
 ----
 
+|no
+
+|[[input_enable_cluster_creator_admin_permissions]] <<input_enable_cluster_creator_admin_permissions,enable_cluster_creator_admin_permissions>>
+|Add the current caller identity (tipycally the Terraform API user) as a cluster administrator via access entry. This is needed to also install the bootstrap Argo CD through Helm. Default to `true`. Set to `false` to manage all access entries with the `access_entries` argument.
+|`bool`
+|`true`
 |no
 
 |[[input_access_entries]] <<input_access_entries,access_entries>>

--- a/main.tf
+++ b/main.tf
@@ -25,10 +25,7 @@ module "cluster" {
 
   cluster_enabled_log_types = var.cluster_enabled_log_types
 
-  # The creator of the cluster tipically is the Terraform API user. This user is then used to also install the bootstrap
-  # Argo CD through Helm, so it needs to access the Kubernetes cluster directly. As such, we hardcode the following
-  # variable to always be true.
-  enable_cluster_creator_admin_permissions = true
+  enable_cluster_creator_admin_permissions = var.enable_cluster_creator_admin_permissions
 
   # Extra API users with administrator access to the EKS cluster.
   access_entries = var.access_entries

--- a/variables.tf
+++ b/variables.tf
@@ -131,6 +131,12 @@ variable "cluster_enabled_log_types" {
   default     = ["audit", "api", "authenticator"]
 }
 
+variable "enable_cluster_creator_admin_permissions" {
+  description = "Add the current caller identity (tipycally the Terraform API user) as a cluster administrator via access entry. This is needed to also install the bootstrap Argo CD through Helm. Default to `true`. Set to `false` to manage all access entries with the `access_entries` argument."
+  type        = bool
+  default     = true
+}
+
 variable "access_entries" {
   description = "Map of access entries to add to the cluster. The type of the variable is `any` similarly to the upstream EKS module. Please check the https://github.com/terraform-aws-modules/terraform-aws-eks[their README] for more information and examples."
   type        = any


### PR DESCRIPTION
The default is true, same as the previously hard-coded value.

It's useful to disable this when running terraform via and SSO and dynamically give admin access to all SSO users, because the same IAM principal can't be used in two access entries.